### PR TITLE
Don't trigger axes computation when accessing cat.codes

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2195,6 +2195,7 @@ class PandasDataframe(ClassLogger):
         keep_partitioning=True,
         sync_labels=True,
         pass_axis_lengths_to_partitions=False,
+        apply_treereduce_func=True,
     ):
         """
         Perform a function across an entire axis.
@@ -2230,6 +2231,10 @@ class PandasDataframe(ClassLogger):
         pass_axis_lengths_to_partitions : bool, default: False
             Whether pass partition lengths along `axis ^ 1` to the kernel `func`.
             Note that `func` must be able to obtain `df, *axis_lengths`.
+        apply_treereduce_func : bool, default: True
+            Whether to wrap `func` with `_build_treereduce_func` or not.
+            There are cases when we don't need to do it, e.g., when the query compiler
+            handles the case and has a hint regarding the proper shape of the result.
 
         Returns
         -------
@@ -2252,6 +2257,7 @@ class PandasDataframe(ClassLogger):
             keep_partitioning=keep_partitioning,
             sync_labels=sync_labels,
             pass_axis_lengths_to_partitions=pass_axis_lengths_to_partitions,
+            apply_treereduce_func=apply_treereduce_func,
         )
 
     @lazy_metadata_decorator(apply_axis="both")
@@ -2645,6 +2651,7 @@ class PandasDataframe(ClassLogger):
         keep_partitioning=True,
         sync_labels=True,
         pass_axis_lengths_to_partitions=False,
+        apply_treereduce_func=True,
     ):
         """
         Broadcast partitions of `other` Modin DataFrame and apply a function along full axis.
@@ -2682,6 +2689,10 @@ class PandasDataframe(ClassLogger):
         pass_axis_lengths_to_partitions : bool, default: False
             Whether pass partition lengths along `axis ^ 1` to the kernel `func`.
             Note that `func` must be able to obtain `df, *axis_lengths`.
+        apply_treereduce_func : bool, default: True
+            Whether to wrap `func` with `_build_treereduce_func` or not.
+            There are cases when we don't need to do it, e.g., when the query compiler
+            handles the case and has a hint regarding the proper shape of the result.
 
         Returns
         -------
@@ -2720,7 +2731,9 @@ class PandasDataframe(ClassLogger):
             axis=axis,
             left=self._partitions,
             right=other,
-            apply_func=self._build_treereduce_func(axis, func),
+            apply_func=func,
+            # if apply_treereduce_func
+            # else func,
             apply_indices=apply_indices,
             enumerate_partitions=enumerate_partitions,
             keep_partitioning=keep_partitioning,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3394,10 +3394,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
             ser = df.iloc[:, 0]
             if ser.dtype != "category":
                 ser = ser.astype("category", copy=False)
-            return ser.cat.codes
+            return ser.cat.codes.to_frame(name=MODIN_UNNAMED_SERIES_LABEL)
 
-        res = self._modin_frame.apply_full_axis(axis=0, func=func)
-        return self.__constructor__(res)
+        res = self._modin_frame.apply_full_axis(
+            axis=0, func=func, new_columns=[MODIN_UNNAMED_SERIES_LABEL]
+        )
+        return self.__constructor__(res, shape_hint="column")
 
     # END Cat operations
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
